### PR TITLE
Add custom H5P xAPI extension for alternatives

### DIFF
--- a/src/scripts/controllers/cloze-controller.ts
+++ b/src/scripts/controllers/cloze-controller.ts
@@ -46,6 +46,14 @@ export class ClozeController {
     return this.cloze.blanks.length;
   }
 
+  /**
+   * Detect whether there are blanks with more than one solution.
+   * @return {boolean} True if there is at least one blank with more than one solution.
+   */
+  public get hasAlternatives(): boolean {
+    return this.cloze.blanks.some(b => b.correctAnswers[0].alternatives.length > 1);
+  }
+
   public get currentScore(): number {
     var score = this.cloze.blanks.filter(b => b.isCorrect).length;
     return Math.max(0, score);
@@ -297,5 +305,5 @@ export class ClozeController {
     }
 
     return result;
-  }  
+  }
 }

--- a/src/scripts/models/xapi.ts
+++ b/src/scripts/models/xapi.ts
@@ -3,5 +3,6 @@ export class XAPIActivityDefinition {
   description: any;
   type: string;
   interactionType: "true-false" | "choice" | "fill-in" | "long-fill-in" | "matching" | "performance" | "sequencing" | "likert" | "numeric" | "other";
-  correctResponsesPattern?: string[]
+  correctResponsesPattern?: string[];
+  extensions: any;
 }


### PR DESCRIPTION
When merged in, the custom H5P xAPI extension for alternatives will be used.

Please note: It seems that in order to fully support the extension, v1.1.0 of the report library is required. It's used on H5P.com, but the [github repository](https://github.com/h5p/h5p-php-report) does only contain the code for v1.0.0. Not sure about the reason, but I asked and am waiting for an answer.

Until v.1.1.0 is available publicly, the report will show the correct score, but it will display all alternatives but the first as wrong even when they are correct.

Resolves https://github.com/sr258/h5p-advanced-blanks/issues/4