### PR TITLE
Fix installation warnings

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -23,6 +23,7 @@ postcss.config.js
 tslint.json
 .gitignore
 TODO
+LICENSE
 h5p-hub-metadata.md
 package-lock.json
 .vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "h5p-advanced-blanks",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
@@ -3034,10 +3035,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
-      "dev": true
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -14250,9 +14255,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npx ava",
     "build": "cross-env NODE_ENV='development' webpack --mode=development && cp node_modules/ractive/ractive.min.js ./dist",
     "build:prod": "cross-env NODE_ENV='production' webpack --mode=production && cp node_modules/ractive/ractive.min.js ./dist",
-    "watch": "webpack --watch"
+    "watch": "webpack --watch --mode=development"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
* in package-lock.json this PR will fix this warning message upon building the content: _Browserslist: caniuse-lite is outdated._
* in package.json this PR will fix this warning message: _The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment._
* in .h5pignore added missing LICENSE will fix error message when uploading content created in dev mode: _Validating h5p package failed. File "H5P.AdvancedBlanks-1.1/LICENSE" not allowed._
Signed-off-by: rezeau <joseph@rezeau.org>